### PR TITLE
Fixed ORDER BY missing when offset 0 in doModifyLimitQuery

### DIFF
--- a/src/Platform/DB2IBMiPlatform.php
+++ b/src/Platform/DB2IBMiPlatform.php
@@ -250,13 +250,13 @@ class DB2IBMiPlatform extends DB2Platform
         $limit = (int) $limit;
         $offset = (int) (($offset)?:0);
 
-        // In cases where an offset isn't required, we can use the much simpler FETCH FIRST (as the ROW_NUMBER() method
+        // In cases where an offset isn't required and there's no ORDER BY, we can use the much simpler FETCH FIRST (as the ROW_NUMBER() method
         // leaves a lot to be desired (i.e. breaks in some cases)
-        if ($offset === 0) {
+        $orderBy = stristr($query, 'ORDER BY');
+
+        if ($offset === 0 && !$orderBy) {
             return sprintf('%s FETCH FIRST %d ROWS ONLY', $query, $limit);
         }
-
-        $orderBy = stristr($query, 'ORDER BY');
 
         $orderByBlocks = preg_split('/\s*ORDER\s+BY/', $orderBy );
 


### PR DESCRIPTION
If the inner query contains a ORDER BY, the doModifyLimitQuery logic must be used to have correct data sorting
