### PR TITLE
Add support for PHP 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,59 @@
+name: "Build"
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                php-version: ["7.1", "8.2"]
+                dependencies: ["highest", "lowest"]
+
+        steps:
+            - name: "Checkout"
+              uses: "actions/checkout@v3"
+              with:
+                  fetch-depth: 2
+
+            - name: "Install IBM i Access ODBC driver"
+              working-directory: /tmp
+              run: |
+                  curl "https://public.dhe.ibm.com/software/ibmi/products/odbc/debs/dists/1.1.0/ibmi-acs-1.1.0.list" | sudo tee /etc/apt/sources.list.d/ibmi-acs-1.1.0.list
+                  sudo apt-get update
+                  sudo apt-get install -qq --yes --no-install-recommends ibm-iaccess
+
+            - name: "Install IBM CLI driver"
+              working-directory: /tmp
+              run: |
+                  wget "https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/linuxx64_odbc_cli.tar.gz"
+                  tar xf linuxx64_odbc_cli.tar.gz
+                  rm linuxx64_odbc_cli.tar.gz
+
+            - name: "Determine version for ibm_db2"
+              id: ibm_db2_ver
+              run: |
+                  if [[ "${{ matrix.php-version }}" == 7.1* ]] || [[ "${{ matrix.php-version }}" == 7.2* ]]; then
+                      echo "ibm_db2_ver=2.1.3" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "ibm_db2_ver=2.1.7" >> "$GITHUB_OUTPUT"
+                  fi;
+
+            - name: "Install PHP"
+              uses: "shivammathur/setup-php@v2"
+              with:
+                  php-version: "${{ matrix.php-version }}"
+                  extensions: "pdo_odbc, ibm_db2-${{ steps.ibm_db2_ver.outputs.ibm_db2_ver }}"
+                  coverage: "pcov"
+                  ini-values: "zend.assertions=1, ibm_db2.instance_name=db2inst1"
+              env:
+                  PDO_ODBC_CONFIGURE_OPTS: "--with-pdo-odbc=unixODBC,/usr"
+                  IBM_DB2_CONFIGURE_OPTS: "--with-IBM_DB2=/tmp/clidriver"
+
+            - name: "Install dependencies with Composer (${{ matrix.dependencies }})"
+              uses: "ramsey/composer-install@v2"
+              with:
+                  dependency-versions: "${{ matrix.dependencies }}"

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "alanseiden/doctrine-dbal-ibmi",
-    "description": "Doctrine DBAL module for DB2 on the IBM i platform",
+    "description": "Doctrine DBAL drivers for DB2 on the IBM i platform",
     "license": "MIT",
     "type": "library",
     "authors": [
@@ -14,15 +14,15 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.0 || ^8.0",
         "doctrine/dbal": "^2.13.9"
     },
     "require-dev": {
         "ext-ibm_db2": "*",
         "ext-pdo_odbc": "*",
         "doctrine/orm": "^2.12",
-        "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-strict-rules": "^1.5",
+        "phpstan/phpstan": "^1.4.10",
+        "phpstan/phpstan-strict-rules": "^1.1",
         "phpunit/phpunit": "^6.5 || ^9.6"
     },
     "suggest": {

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -26,8 +26,8 @@ class Bootstrap
     public static function getEntityManager()
     {
         if (null === self::$entityManager) {
-            if (!extension_loaded('ibm_db2') && !extension_loaded('pdo')) {
-                throw new SkippedTestError('Neither DB2 nor PDO connections are available, skipping test');
+            if (!extension_loaded('ibm_db2') && !extension_loaded('pdo_odbc')) {
+                throw new SkippedTestError('Neither ibm_db2 nor pdo_odbc extensions are available, skipping test');
             }
 
             $configuration = ORMSetup::createAnnotationMetadataConfiguration([

--- a/test/unit/Driver/OdbcIbmiConnectionTest.php
+++ b/test/unit/Driver/OdbcIbmiConnectionTest.php
@@ -15,8 +15,8 @@ final class OdbcIbmiConnectionTest extends TestCase
      */
     public function testCorrectConnectionClassIsUsed()
     {
-        if (!extension_loaded('pdo')) {
-            self::markTestSkipped('pdo extension not loaded');
+        if (!extension_loaded('pdo_odbc')) {
+            self::markTestSkipped('pdo_odbc extension not loaded');
         }
         $em = Bootstrap::getEntityManager();
 


### PR DESCRIPTION
Closes #20.

Ideally, this PR should be merged after #29.

Lowest and highest deps are ensured in the CI pipeline.

**TODO**:
- [x] Check if a new MINOR version (`0.1.0`) should be released before this PR;
- [x] Check if there are more changes to do leveraging the removed support for PHP < 7.