### PR TITLE
Drop support for PHP < 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0|^7.1",
-        "doctrine/dbal": "^2.5"
+        "php": "^7.0",
+        "doctrine/dbal": "^2.6"
     },
     "require-dev": {
-        "doctrine/orm": "^2.0.0",
-        "phpunit/phpunit": "^5.6"
+        "doctrine/orm": "^2.5",
+        "phpunit/phpunit": "^6.5 || ^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
-<phpunit bootstrap="test/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="UnitTest">
             <directory>./test/unit</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/test/unit/Driver/DB2IBMiConnectionTest.php
+++ b/test/unit/Driver/DB2IBMiConnectionTest.php
@@ -4,11 +4,12 @@ namespace DoctrineDbalIbmiTest\Driver;
 
 use DoctrineDbalIbmi\Driver\DB2IBMiConnection;
 use DoctrineDbalIbmiTest\Bootstrap;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DoctrineDbalIbmi\Driver\DB2IBMiConnection
  */
-class DB2IBMiConnectionTest extends \PHPUnit_Framework_TestCase
+class DB2IBMiConnectionTest extends TestCase
 {
     public function testCorrectConnectionClassIsUsed()
     {

--- a/test/unit/Driver/OdbcIbmiConnectionTest.php
+++ b/test/unit/Driver/OdbcIbmiConnectionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DoctrineDbalIbmiTest\Driver;
 
-use DoctrineDbalIbmi\Driver\DB2IBMiConnection;
 use DoctrineDbalIbmi\Driver\OdbcIBMiConnection;
 use DoctrineDbalIbmiTest\Bootstrap;
 use PHPUnit\Framework\TestCase;

--- a/test/unit/Platform/DB2IBMiPlatformTest.php
+++ b/test/unit/Platform/DB2IBMiPlatformTest.php
@@ -4,11 +4,12 @@ namespace DoctrineDbalIbmiTest\Platform;
 
 use DoctrineDbalIbmi\Platform\DB2IBMiPlatform;
 use DoctrineDbalIbmiTest\Bootstrap;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DoctrineDbalIbmi\Platform\DB2IBMiPlatform
  */
-class DB2IBMiPlatformTest extends \PHPUnit_Framework_TestCase
+class DB2IBMiPlatformTest extends TestCase
 {
     public function typeMappingProvider()
     {


### PR DESCRIPTION
"doctrine/dbal" dropped support for PHP < 7 more than 6 years ago.
Replicating the bump here will help with the fix of several bugs (that must be discussed in next PRs).

BTW, `^7.1` was removed from the constraint because `^7.0` implies `>=7.0, <8.0`.

See doctrine/dbal#2590.