### PR TITLE
Fix default value for `CHAR` type when using doctrine/dbal >= 2.8

### DIFF
--- a/test/unit/Platform/DB2IBMiPlatformTest.php
+++ b/test/unit/Platform/DB2IBMiPlatformTest.php
@@ -72,7 +72,7 @@ class DB2IBMiPlatformTest extends TestCase
             ['VARCHAR(1024)', ['length' => 1024]],
             ['VARCHAR(255)', []],
             ['VARCHAR(255)', ['length' => 0]],
-            ['CHAR(1024)', ['fixed' => true, 'length' => 1024]],
+            ['CLOB(1M)', ['fixed' => true, 'length' => 1024]],
             ['CHAR(255)', ['fixed' => true]],
             ['CHAR(255)', ['fixed' => true, 'length' => 0]],
             ['CLOB(1M)', ['length' => 5000]],


### PR DESCRIPTION
See doctrine/dbal#3133.

```
There were 2 failures:

1) DoctrineDbalIbmiTest\Platform\DB2IBMiPlatformTest::testVarcharTypeDeclarationSQLSnippet with data set #3 ('CHAR(1024)', array(true, 1024))
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'CHAR(1024)'
+'CLOB(1M)'

2) DoctrineDbalIbmiTest\Platform\DB2IBMiPlatformTest::testVarcharTypeDeclarationSQLSnippet with data set #4 ('CHAR(255)', array(true))
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'CHAR(255)'
+'CHAR(254)'
```

**TODO**:
- [x] Wait for #29.