### PR TITLE
Update driver names

### DIFF
--- a/src/Driver/DB2Driver.php
+++ b/src/Driver/DB2Driver.php
@@ -38,6 +38,6 @@ class DB2Driver extends AbstractDB2Driver
      */
     public function getName()
     {
-        return 'ibm_db2';
+        return 'ibm_db2_i';
     }
 }

--- a/src/Driver/OdbcDriver.php
+++ b/src/Driver/OdbcDriver.php
@@ -44,7 +44,7 @@ class OdbcDriver extends AbstractDB2Driver implements VersionAwarePlatformDriver
      */
     public function getName()
     {
-        return 'odbc';
+        return 'pdo_odbc_ibm_db2_i';
     }
 
     public function createDatabasePlatformForVersion($version)

--- a/tests/Driver/DB2DriverTest.php
+++ b/tests/Driver/DB2DriverTest.php
@@ -60,4 +60,9 @@ final class DB2DriverTest extends AbstractDriverTestCase
             ],
         ];
     }
+
+    public function testGetName(): void
+    {
+        self::assertSame('ibm_db2_i', (new DB2Driver())->getName());
+    }
 }

--- a/tests/Driver/OdbcDriverTest.php
+++ b/tests/Driver/OdbcDriverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineDbalIbmi\Tests\Driver;
 
+use Doctrine\DBAL\DriverManager;
 use DoctrineDbalIbmi\Driver\OdbcDriver;
 
 final class OdbcDriverTest extends AbstractDriverTestCase
@@ -41,5 +42,10 @@ final class OdbcDriverTest extends AbstractDriverTestCase
                 'port' => 60000,
             ],
         ];
+    }
+
+    public function testGetName(): void
+    {
+        self::assertSame('pdo_odbc_ibm_db2_i', (new OdbcDriver())->getName());
     }
 }


### PR DESCRIPTION
In order to avoid collisions with the [existing built-in DBAL driver names](https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/configuration.html#connection-details), we should use unique and proper driver names.

Related to #28.