### PR TITLE
Allow uncataloged connections on localhost

### DIFF
--- a/src/Driver/DB2Driver.php
+++ b/src/Driver/DB2Driver.php
@@ -11,22 +11,32 @@ class DB2Driver extends AbstractDB2Driver
      */
     public function connect(array $params, $username = null, $password = null, array $driverOptions = array())
     {
-        if ( ! isset($params['protocol'])) {
+        if ('' === ($params['protocol'] ?? '')) {
             $params['protocol'] = 'TCPIP';
         }
 
-        if ($params['host'] !== 'localhost' && $params['host'] != '127.0.0.1') {
-            // if the host isn't localhost, use extended connection params
+        if ('' === ($username ?? '')) {
+            $username = $params['user'] ?? null;
+        }
+
+        if ('' === ($password ?? '')) {
+            $password = $params['password'] ?? null;
+        }
+
+        // Check if the "dbname" parameter has an uncataloged database DSN.
+        if (isset($params['host']) && false === strpos($params['dbname'], '=')) {
             $params['dbname'] = 'DRIVER={IBM DB2 ODBC DRIVER}' .
                 ';DATABASE=' . $params['dbname'] .
                 ';HOSTNAME=' . $params['host'] .
                 ';PROTOCOL=' . $params['protocol'] .
-                ';UID='      . $username .
-                ';PWD='      . $password .';';
+                ';UID=' . $username .
+                ';PWD=' . $password . ';';
+
             if (isset($params['port'])) {
                 $params['dbname'] .= 'PORT=' . $params['port'];
             }
 
+            unset($params['user'], $params['password'], $params['host'], $params['port'], $params['protocol']);
             $username = null;
             $password = null;
         }


### PR DESCRIPTION
IMO, assuming arbitrarily that the hosts "localhost" or "127.0.0.1" are using a cataloged database and others don't is a very opinionated restriction.
I guess detecting the presence of the "=" char in the `dbname` parameter is a better approach.

Related to #32.
You can see the tests for these changes in #39.