### PR TITLE
Fix error on `DB2IBMiPlatform::doModifyLimitQuery()` when `ORDER BY` clause is not present

### DIFF
--- a/src/Platform/DB2IBMiPlatform.php
+++ b/src/Platform/DB2IBMiPlatform.php
@@ -290,7 +290,7 @@ class DB2IBMiPlatform extends DB2Platform
 
         $orderBy = stristr($query, 'ORDER BY');
 
-        assert(false !== $orderBy);
+        $orderBy = false === $orderBy ? '' : $orderBy;
 
         $orderByBlocks = preg_split('/\s*ORDER\s+BY/', $orderBy);
 


### PR DESCRIPTION
This issue was introduced in [#25](https://github.com/SeidenGroup/doctrine-dbal-ibmi/pull/25/files#diff-b4ea67761a28859d637216795fb02590ae6c420c176a8850bd8c3851fe944d8fR292) (my bad).