### PR TITLE
Move tests that use database connections under `DoctrineDbalIbmi\Tests\Functional` namespace

### DIFF
--- a/tests/Functional/Driver/DB2IBMiConnectionTest.php
+++ b/tests/Functional/Driver/DB2IBMiConnectionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoctrineDbalIbmi\Tests\Driver;
+namespace DoctrineDbalIbmi\Tests\Functional\Driver;
 
 use Doctrine\DBAL\DriverManager;
 use DoctrineDbalIbmi\Driver\DB2Driver;

--- a/tests/Functional/Driver/OdbcIbmiConnectionTest.php
+++ b/tests/Functional/Driver/OdbcIbmiConnectionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DoctrineDbalIbmi\Tests\Driver;
+namespace DoctrineDbalIbmi\Tests\Functional\Driver;
 
 use DoctrineDbalIbmi\Driver\OdbcDriver;
 use DoctrineDbalIbmi\Driver\OdbcIBMiConnection;


### PR DESCRIPTION
This way, the tests under `DoctrineDbalIbmi\Tests` remain unitary.
This structure is also implemented in [`doctrine/dbal`](https://github.com/doctrine/dbal/tree/3.6.x/tests/Functional/Driver/IBMDB2).