### PR TITLE
Remove method overrides that don't bring any added value

### DIFF
--- a/src/Driver/AbstractDB2Driver.php
+++ b/src/Driver/AbstractDB2Driver.php
@@ -28,9 +28,14 @@ abstract class AbstractDB2Driver implements Driver
         $params = DataSourceName::fromConnectionParameters($conn->getParams())
             ->getConnectionParameters();
 
-        assert(is_string($params['dbname']));
+        // In iSeries systems, with SQL naming, the default database name is specified in ['driverOptions' => ['i5_lib' = ?]]
+        $database = DB2Driver::class === $params['driverClass'] && isset($params['driverOptions']['i5_lib']) ?
+            $params['driverOptions']['i5_lib'] :
+            $params['dbname'];
 
-        return $params['dbname'];
+        assert(is_string($database));
+
+        return $database;
     }
 
     /**

--- a/src/Driver/OdbcDriver.php
+++ b/src/Driver/OdbcDriver.php
@@ -2,10 +2,8 @@
 
 namespace DoctrineDbalIbmi\Driver;
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\VersionAwarePlatformDriver;
 use DoctrineDbalIbmi\Platform\DB2IBMiPlatform;
-use DoctrineDbalIbmi\Schema\DB2IBMiSchemaManager;
 
 class OdbcDriver extends AbstractDB2Driver implements VersionAwarePlatformDriver
 {
@@ -52,21 +50,5 @@ class OdbcDriver extends AbstractDB2Driver implements VersionAwarePlatformDriver
     public function createDatabasePlatformForVersion($version)
     {
         return new DB2IBMiPlatform();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDatabasePlatform()
-    {
-        return new DB2IBMiPlatform();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSchemaManager(Connection $conn)
-    {
-        return new DB2IBMiSchemaManager($conn);
     }
 }

--- a/src/Platform/DB2IBMiPlatform.php
+++ b/src/Platform/DB2IBMiPlatform.php
@@ -108,6 +108,8 @@ class DB2IBMiPlatform extends DB2Platform
      */
     public function getListTableColumnsSQL($table, $database = null)
     {
+        assert(null !== $database);
+
         return "
             SELECT DISTINCT
                c.column_def as default,
@@ -143,80 +145,79 @@ class DB2IBMiPlatform extends DB2Platform
                     ON tc.CONSTRAINT_NAME = spk.PK_NAME AND tc.TABLE_SCHEMA = spk.TABLE_SCHEM AND tc.TABLE_NAME = spk.TABLE_NAME
                 WHERE CONSTRAINT_TYPE = 'PRIMARY KEY'
                 AND UPPER(tc.TABLE_NAME) = UPPER('" . $table . "')
-                ". ($database !== null ? "AND tc.TABLE_SCHEMA = UPPER('" . $database . "')" : '') ."
+                AND tc.TABLE_SCHEMA = UPPER('" . $database . "')
              ) pk ON
                 c.TABLE_SCHEM = pk.TABLE_SCHEMA
                 AND c.TABLE_NAME = pk.TABLE_NAME
                 AND c.COLUMN_NAME = pk.COLUMN_NAME
              WHERE
                 UPPER(c.TABLE_NAME) = UPPER('" . $table . "')
-                ". ($database  !== null ? "AND c.TABLE_SCHEM = UPPER('" . $database . "')" : '') ."
+                AND c.TABLE_SCHEM = UPPER('" . $database . "')
              ORDER BY c.ordinal_position
         ";
     }
 
     /**
-     * @param string|null $database
+     * @param string $database
      *
      * {@inheritDoc}
      */
     public function getListTablesSQL($database = null)
     {
+        assert(null !== $database);
+
         return "
             SELECT
-              DISTINCT NAME
+                DISTINCT NAME
             FROM
                 SYSIBM.tables t
             WHERE
-              table_type='BASE TABLE'
-              ". ($database !== null ? "AND t.TABLE_SCHEMA = UPPER('" . $database . "')" : '') ."
+                table_type = 'BASE TABLE'
+                AND t.TABLE_SCHEMA = UPPER('" . $database . "')
             ORDER BY NAME
         ";
     }
 
     /**
-     * @param string|null $database
-     *
      * {@inheritDoc}
      */
-    public function getListViewsSQL($database = null)
+    public function getListViewsSQL($database)
     {
         return "
             SELECT
               DISTINCT NAME,
               TEXT
             FROM QSYS2.sysviews v
-            WHERE 1=1
-            ". ($database !== null ? "AND v.TABLE_SCHEMA = UPPER('" . $database . "')" : '') ."
+            WHERE v.TABLE_SCHEMA = UPPER('" . $database . "')
             ORDER BY NAME
         ";
     }
 
     /**
-     * @param string|null $database
-     *
      * {@inheritDoc}
      */
     public function getListTableIndexesSQL($table, $database = null)
     {
-        return  "
+        assert(null !== $database);
+
+        return "
             SELECT
-                  scc.CONSTRAINT_NAME as key_name,
-                  scc.COLUMN_NAME as column_name,
-                  CASE
-                      WHEN sc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 1
-                      ELSE 0
-                  END AS primary,
-                  CASE
-                      WHEN sc.CONSTRAINT_TYPE = 'UNIQUE' THEN 0
-                      ELSE 1
-                  END AS non_unique
-              FROM
-              QSYS2.syscstcol scc
-              LEFT JOIN QSYS2.syscst sc ON
-                  scc.TABLE_SCHEMA = sc.TABLE_SCHEMA AND scc.TABLE_NAME = sc.TABLE_NAME AND scc.CONSTRAINT_NAME = sc.CONSTRAINT_NAME
+                scc.CONSTRAINT_NAME as key_name,
+                scc.COLUMN_NAME as column_name,
+                CASE
+                    WHEN sc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 1
+                    ELSE 0
+                END AS primary,
+                CASE
+                    WHEN sc.CONSTRAINT_TYPE = 'UNIQUE' THEN 0
+                    ELSE 1
+                END AS non_unique
+            FROM
+            QSYS2.syscstcol scc
+            LEFT JOIN QSYS2.syscst sc ON
+                scc.TABLE_SCHEMA = sc.TABLE_SCHEMA AND scc.TABLE_NAME = sc.TABLE_NAME AND scc.CONSTRAINT_NAME = sc.CONSTRAINT_NAME
             WHERE scc.TABLE_NAME = UPPER('" . $table . "')
-            ". ($database !== null ? "AND scc.TABLE_SCHEMA = UPPER('" . $database . "')" : '') ."
+            AND scc.TABLE_SCHEMA = UPPER('" . $database . "')
         ";
     }
 
@@ -227,6 +228,8 @@ class DB2IBMiPlatform extends DB2Platform
      */
     public function getListTableForeignKeysSQL($table, $database = null)
     {
+        assert(null !== $database);
+
         return "
             SELECT DISTINCT
                 fk.COLUMN_NAME AS local_column,
@@ -243,7 +246,7 @@ class DB2IBMiPlatform extends DB2Platform
                 rc.UNIQUE_CONSTRAINT_SCHEMA = pk.CONSTRAINT_SCHEMA AND
                 rc.UNIQUE_CONSTRAINT_NAME = pk.CONSTRAINT_NAME
             WHERE fk.TABLE_NAME = UPPER('" . $table . "')
-            " . ($database !== null ? "AND fk.TABLE_SCHEMA = UPPER('" . $database . "')" : '') . "
+            AND fk.TABLE_SCHEMA = UPPER('" . $database . "')
         ";
     }
 

--- a/src/Schema/DB2IBMiSchemaManager.php
+++ b/src/Schema/DB2IBMiSchemaManager.php
@@ -2,6 +2,7 @@
 
 namespace DoctrineDbalIbmi\Schema;
 
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\DB2SchemaManager;
 use Doctrine\DBAL\Types\Type;
@@ -13,89 +14,12 @@ class DB2IBMiSchemaManager extends DB2SchemaManager
      */
     public function listTableNames()
     {
-        $sql = $this->_platform->getListTablesSQL($this->getDatabase());
+        $sql = $this->_platform->getListTablesSQL($this->_conn->getDatabase());
 
         $tables = $this->_conn->fetchAll($sql);
         $tableNames = $this->_getPortableTablesList($tables);
 
         return $this->filterAssetNames($tableNames);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function listSequences($database = null)
-    {
-        if (null === $database) {
-            $database = $this->getDatabase();
-        }
-
-        assert(null !== $database);
-
-        $sql = $this->_platform->getListSequencesSQL($database);
-
-        $sequences = $this->_conn->fetchAll($sql);
-
-        return $this->filterAssetNames($this->_getPortableSequencesList($sequences));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function listTableColumns($table, $database = null)
-    {
-        if (null === $database) {
-            $database = $this->getDatabase();
-        }
-
-        assert(null !== $database);
-
-        $sql = $this->_platform->getListTableColumnsSQL($table, $database);
-
-        $tableColumns = $this->_conn->fetchAll($sql);
-
-        return $this->_getPortableTableColumnList($table, $database, $tableColumns);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function listTableIndexes($table)
-    {
-        $sql = $this->_platform->getListTableIndexesSQL($table, $this->getDatabase());
-
-        $tableIndexes = $this->_conn->fetchAll($sql);
-
-        return $this->_getPortableTableIndexesList($tableIndexes, $table);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function listViews()
-    {
-        $database = $this->getDatabase();
-
-        assert(null !== $database);
-
-        $sql = $this->_platform->getListViewsSQL($database);
-        $views = $this->_conn->fetchAll($sql);
-
-        return $this->_getPortableViewsList($views);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function listTableForeignKeys($table, $database = null)
-    {
-        if (is_null($database)) {
-            $database = $this->getDatabase();
-        }
-        $sql = $this->_platform->getListTableForeignKeysSQL($table, $database);
-        $tableForeignKeys = $this->_conn->fetchAll($sql);
-
-        return $this->_getPortableTableForeignKeysList($tableForeignKeys);
     }
 
     /**
@@ -176,16 +100,12 @@ class DB2IBMiSchemaManager extends DB2SchemaManager
     /**
      * Returns database name
      *
-     * @return string|null
+     * @deprecated To be removed in the next major version, use `Connection::getDatabase()` instead.
+     *
+     * @return string
      */
     protected function getDatabase()
     {
-        // In iSeries systems, with SQL naming, the default database name is specified in driverOptions['i5_lib']
-        $dbParams = $this->_conn->getParams();
-        if (array_key_exists('driverOptions', $dbParams) && array_key_exists('i5_lib', $dbParams['driverOptions'])) {
-            return $dbParams['driverOptions']['i5_lib'];
-        }
-
-        return null;
+        return $this->_conn->getDatabase();
     }
 }


### PR DESCRIPTION
* Method `DB2IBMiSchemaManager::getDatabase()` is deprecated in favor of `Connection::getDatabase()`;
* Method `DB2IBMiSchemaManager::listSequences()` is removed as it is identical to its parent definition at `AbstractSchemaManager`;
* Method `DB2IBMiSchemaManager::listTableColumns()` is removed as it is identical to its parent definition at `AbstractSchemaManager`;
* Method `DB2IBMiSchemaManager::listTableIndexes()` is removed as it is identical to its parent definition at `AbstractSchemaManager`;
* Method `DB2IBMiSchemaManager::listViews()` is removed as it is identical to its parent definition at `AbstractSchemaManager`;
* Method `DB2IBMiSchemaManager::listTableForeignKeys()` is removed as it is identical to its parent definition at `AbstractSchemaManager`;
* Default `null` value removed from `$database` parameter in `getListViewsSQL()`, as it is always provided with type `string`;
* Method `OdbcDriver::getSchemaManager()` is removed as it is identical to its parent definition at `AbstractDB2Driver`;
* Method `OdbcDriver::getDatabasePlatform()` is removed as it is identical to its parent definition at `AbstractDB2Driver`.

**TODO**:
- [x] Provide a reliable way to get the database name at `AbstractDB2Driver::getDatabase()` (by instance, from DSN or cataloged connections) (requires #32).