### PR TITLE
Use the recommended `FETCH NEXT x ROWS` clause instead of `LIMIT x`

### DIFF
--- a/src/Platform/DB2IBMiPlatform.php
+++ b/src/Platform/DB2IBMiPlatform.php
@@ -333,25 +333,16 @@ SQL
      */
     protected function doModifyLimitQuery($query, $limit, $offset = null)
     {
-        if (null === $limit) {
-            return $query;
-        }
-
-        if ($limit < 0) {
-            throw new Exception(sprintf('Limit must be a positive integer or zero, %d given', $limit));
-        }
-
-        if (0 === $offset && false === strpos($query, 'ORDER BY')) {
-            // In cases where an offset isn't required and there's no "ORDER BY" clause,
-            // we can use the much simpler "FETCH FIRST".
-
-            return sprintf('%s FETCH FIRST %u ROWS ONLY', $query, $limit);
-        }
-
-        $query .= sprintf(' LIMIT %u', $limit);
-
         if ($offset > 0) {
-            $query .= sprintf(' OFFSET %u', $offset);
+            $query .= sprintf(' OFFSET %u ROW%s', $offset, 1 === $offset ? '' : 'S');
+        }
+
+        if (null !== $limit) {
+            if ($limit < 0) {
+                throw new Exception(sprintf('Limit must be a positive integer or zero, %d given', $limit));
+            }
+
+            $query .= sprintf(' FETCH %s %u ROW%s ONLY', 0 === $offset ? 'FIRST' : 'NEXT', $limit, 1 === $limit ? '' : 'S');
         }
 
         return $query;

--- a/tests/Platform/DB2IBMiPlatformTest.php
+++ b/tests/Platform/DB2IBMiPlatformTest.php
@@ -107,21 +107,21 @@ final class DB2IBMiPlatformTest extends AbstractTestCase
     public function limitQueryProvider(): iterable
     {
         yield [
-            'SELECT * FROM mytable LIMIT 5 OFFSET 2',
+            'SELECT * FROM mytable OFFSET 2 ROWS FETCH NEXT 5 ROWS ONLY',
             'SELECT * FROM mytable',
             5,
             2,
         ];
 
         yield [
-            'SELECT * FROM mytable LIMIT 1 OFFSET 1',
+            'SELECT * FROM mytable OFFSET 1 ROW FETCH NEXT 1 ROW ONLY',
             'SELECT * FROM mytable',
             1,
             1,
         ];
 
         yield [
-            'SELECT * FROM mytable LIMIT 1 OFFSET 2',
+            'SELECT * FROM mytable OFFSET 2 ROWS FETCH NEXT 1 ROW ONLY',
             'SELECT * FROM mytable',
             1,
             2,
@@ -135,21 +135,21 @@ final class DB2IBMiPlatformTest extends AbstractTestCase
         ];
 
         yield [
-            'SELECT * FROM mytable FETCH FIRST 1 ROWS ONLY',
+            'SELECT * FROM mytable FETCH FIRST 1 ROW ONLY',
             'SELECT * FROM mytable',
             1,
             0,
         ];
 
         yield [
-            'SELECT * FROM mytable FETCH FIRST 1 ROWS ONLY',
+            'SELECT * FROM mytable FETCH FIRST 1 ROW ONLY',
             'SELECT * FROM mytable',
             1,
             null,
         ];
 
         yield [
-            'SELECT * FROM mytable',
+            'SELECT * FROM mytable OFFSET 1 ROW',
             'SELECT * FROM mytable',
             null,
             1,
@@ -163,21 +163,21 @@ final class DB2IBMiPlatformTest extends AbstractTestCase
         ];
 
         yield [
-            'SELECT * FROM mytable ORDER BY created_at LIMIT 1',
+            'SELECT * FROM mytable ORDER BY created_at FETCH FIRST 1 ROW ONLY',
             'SELECT * FROM mytable ORDER BY created_at',
             1,
             0,
         ];
 
         yield [
-            'SELECT * FROM mytable ORDER BY created_at LIMIT 1',
+            'SELECT * FROM mytable ORDER BY created_at FETCH FIRST 1 ROW ONLY',
             'SELECT * FROM mytable ORDER BY created_at',
             1,
             null,
         ];
 
         yield [
-            'SELECT * FROM mytable ORDER BY created_at LIMIT 0',
+            'SELECT * FROM mytable ORDER BY created_at FETCH FIRST 0 ROWS ONLY',
             'SELECT * FROM mytable ORDER BY created_at',
             0,
             0,
@@ -191,7 +191,7 @@ final class DB2IBMiPlatformTest extends AbstractTestCase
         ];
 
         yield [
-            'SELECT * FROM mytable ORDER BY created_at LIMIT 0',
+            'SELECT * FROM mytable ORDER BY created_at FETCH FIRST 0 ROWS ONLY',
             'SELECT * FROM mytable ORDER BY created_at',
             0,
             null,


### PR DESCRIPTION
`LIMIT x` and `OFFSET y` are considered alternative syntax.

See:
* https://www.ibm.com/docs/en/i/7.3?topic=reference-whats-new-i-73;
* https://www.ibm.com/docs/en/i/7.3?topic=cursor-example-using-offset-clause;
* https://www.ibm.com/docs/en/i/7.3?topic=subselect-fetch-clause;