### PR TITLE
Implement `VersionAwarePlatformDriver` at `AbstractDB2Driver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build and test](https://github.com/SeidenGroup/doctrine-dbal-ibmi/actions/workflows/test.yml/badge.svg)](https://github.com/SeidenGroup/doctrine-dbal-ibmi/actions/workflows/test.yml)
 
 [Doctrine DBAL](https://www.doctrine-project.org/projects/doctrine-dbal/en/current/reference/introduction.html#introduction)
-drivers for [DB2 on the IBM i platform](https://www.ibm.com/docs/en/i/7.4?topic=overview-db2-i).
+drivers for [DB2 on the IBM i platform](https://www.ibm.com/docs/en/i/7.4?topic=overview-db2-i) (version [7.3](https://www.ibm.com/docs/en/i/7.3?topic=reference-whats-new-i-73) and higher).
 
 Based on the original work by [@cassvail](https://github.com/cassvail) in [doctrine/dbal#910](https://github.com/doctrine/dbal/pull/910).
 

--- a/src/Driver/OdbcDriver.php
+++ b/src/Driver/OdbcDriver.php
@@ -10,7 +10,6 @@
 namespace DoctrineDbalIbmi\Driver;
 
 use Doctrine\DBAL\VersionAwarePlatformDriver;
-use DoctrineDbalIbmi\Platform\DB2IBMiPlatform;
 
 class OdbcDriver extends AbstractDB2Driver implements VersionAwarePlatformDriver
 {
@@ -52,10 +51,5 @@ class OdbcDriver extends AbstractDB2Driver implements VersionAwarePlatformDriver
     public function getName()
     {
         return 'pdo_odbc_ibm_db2_i';
-    }
-
-    public function createDatabasePlatformForVersion($version)
-    {
-        return new DB2IBMiPlatform();
     }
 }

--- a/src/Driver/OdbcIBMiConnection.php
+++ b/src/Driver/OdbcIBMiConnection.php
@@ -95,12 +95,4 @@ class OdbcIBMiConnection extends Connection
 
         return $handle;
     }
-
-    /**
-     * @return true
-     */
-    public function requiresQueryForServerVersion()
-    {
-        return true;
-    }
 }


### PR DESCRIPTION
We are already using features that are only available in DB2 for i 7.3 or higher.
With this change, we can be sure the users have a proper version for these drivers.